### PR TITLE
docs: professionalize repository administration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a reproducible defect
+title: "fix: "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+
+## Steps to Reproduce
+
+1.
+
+## Expected Behavior
+
+
+## Actual Behavior
+
+
+## Environment
+
+- OS:
+- Runtime/version:
+- Commit:
+
+## Logs
+
+```text
+
+```

--- a/.github/ISSUE_TEMPLATE/technical_debt.md
+++ b/.github/ISSUE_TEMPLATE/technical_debt.md
@@ -1,0 +1,23 @@
+---
+name: Technical debt
+about: Track cleanup, governance, or repository maintenance
+title: "chore: "
+labels: technical-debt
+assignees: ""
+---
+
+## Problem
+
+
+## Evidence
+
+
+## Proposed Resolution
+
+
+## Risk
+
+
+## Acceptance Criteria
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+-
+
+## Implementation Status
+
+- [ ] Implemented
+- [ ] Partially implemented
+- [ ] Prototype
+- [ ] Documentation only
+- [ ] Follow-up required
+
+## Tests / Checks
+
+- [ ] Relevant tests passed
+- [ ] Documentation-only change
+- [ ] Not run:
+
+## Risk Notes
+
+-
+
+## Rollback
+
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+## Development Principles
+
+- Keep changes focused and reversible.
+- Do not mix code changes with repository administration unless necessary.
+- Do not commit secrets or local environment files.
+- For larger tasks, plan first, validate assumptions, then implement in small steps.
+
+## Local Workflow
+
+1. Create a branch from `main`.
+2. Make focused changes.
+3. Run the relevant checks for the repository.
+4. Open a pull request with summary, tests, risk notes, and rollback plan.
+
+## Documentation
+
+When updating documentation, distinguish clearly between implemented behavior, partial behavior, prototypes, and future plans.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting Security Issues
+
+Do not open public issues with secrets, exploit details, production credentials, or sensitive customer data. Report privately to the repository owner.
+
+## Secret Handling
+
+- Never commit real credentials.
+- Never store real credentials in `.env` files committed to the repository.
+- Keep `.env.example` limited to placeholder values.
+- Rotate any credential that may have been exposed.
+
+## Supported Security Baseline
+
+- Review dependency changes before merging.
+- Keep administrative changes separate from runtime code changes.
+- Require explicit confirmation before destructive operations.

--- a/docs/architecture/REPOSITORY_STRUCTURE.md
+++ b/docs/architecture/REPOSITORY_STRUCTURE.md
@@ -1,0 +1,20 @@
+# Repository Structure
+
+This guide identifies the administrative documentation layout for STARDF Anime.
+
+## Administrative Documentation
+
+- `docs/governance/`: governance, security, approval, audit, and rollback rules.
+- `docs/development/`: contributor and Git workflow guidance.
+- `docs/architecture/`: repository structure and architecture notes.
+- `.github/`: pull request templates, issue templates, and GitHub workflow metadata.
+
+## Source Code
+
+Source code stays in the repository's existing application directories. This organization pass does not move or rewrite code.
+
+## Documentation Policy
+
+- Keep documentation close to the current repository reality.
+- Mark future ideas as roadmap or proposal, not implemented functionality.
+- Prefer concise documents that help contributors make safe changes.

--- a/docs/development/GIT_WORKFLOW.md
+++ b/docs/development/GIT_WORKFLOW.md
@@ -1,0 +1,30 @@
+# Git Workflow
+
+## Branches
+
+- `main`: stable branch. No direct administrative work unless explicitly approved.
+- `develop`: optional integration branch for repositories that need staged releases.
+- `feature/*`: new functionality.
+- `fix/*`: bug fixes.
+- `docs/*`: documentation-only changes.
+- `chore/*`: maintenance and repository administration.
+
+## Pull Requests
+
+- Open a pull request for every meaningful change.
+- Keep code changes separate from repository-organization changes.
+- Use the PR template when available.
+- Include verification commands and rollback notes.
+- Do not merge automatically unless the repository owner requested it.
+
+## Commits
+
+- Prefer focused commits with clear prefixes: `docs:`, `chore:`, `fix:`, `feat:`, `test:`.
+- Do not commit secrets, generated caches, local databases, build artifacts, or personal environment files.
+- Avoid large mixed commits that combine code, formatting, and documentation.
+
+## Rollback
+
+- Documentation changes should be revertible with `git revert`.
+- Runtime changes should describe data migrations and operational side effects.
+- Force push, reset, delete, and drop operations require explicit confirmation.

--- a/docs/governance/GOVERNANCE.md
+++ b/docs/governance/GOVERNANCE.md
@@ -1,0 +1,35 @@
+# Governance
+
+This repository uses documentation-first governance for administrative, security, and delivery decisions.
+
+## Scope
+
+- Keep code changes separate from documentation and repository administration work.
+- Prefer small, reversible pull requests.
+- Record assumptions, risks, and validation steps in every non-trivial PR.
+- Do not claim a feature is complete unless the code and tests support that status.
+
+## Security Rules
+
+- Do not commit API keys, tokens, passwords, credentials, private certificates, or production data.
+- Do not create `.env` files with real secrets.
+- Use `.env.example` only for variable names and safe placeholder values.
+- Consume credentials from the approved secure vault or runtime environment.
+- Review logs, screenshots, and generated reports before publishing them.
+
+## Change Control
+
+- Destructive changes require explicit confirmation and a rollback plan.
+- Runtime behavior changes require tests or a documented reason when tests are not feasible.
+- Dependency changes require a risk note when they affect production execution.
+- Documentation-only changes should state that no runtime behavior was changed.
+
+## Audit Requirements
+
+Every PR should include:
+
+- Summary of changes.
+- Implementation status.
+- Tests or checks run.
+- Risk notes.
+- Rollback plan.


### PR DESCRIPTION
## Summary

Repository administration and documentation-only professionalization.

Changes included:
- Adds governance documentation under `docs/governance/`.
- Adds Git workflow guidance under `docs/development/`.
- Adds repository structure guidance under `docs/architecture/`.
- Adds security/contribution/PR/issue administrative templates.

## Implementation Status

Documentation only. No application source code, tests, build configuration, runtime configuration, or secrets were changed.

## Tests / Checks

- `git diff main..HEAD --check` passed locally.
- Local pre-commit secret scan passed during commit.
- Full runtime test suite was not run because this PR is documentation-only.

## Risk Notes

Low runtime risk: administrative documentation and templates only.

## Rollback

Revert the single commit on this branch to restore the previous administrative-documentation state.